### PR TITLE
Use ready-to-use bitmap instead of converting manually

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -290,38 +290,19 @@ namespace Windows_Task_Dialog_Generator
             }
         }
 
-        private static Icon? GetIconFromImageRes(int id)
+        private static Image? GetIconImageFromImageRes(int id, int size)
         {
             string winPath = Environment.GetFolderPath(Environment.SpecialFolder.System);
             string imageresPath = Path.Combine(winPath, "imageres.dll");
             try
             {
-                Icon? icon = System.Drawing.Icon.ExtractIcon(imageresPath, -1 * id); // Negative ID to extract from imageres.dll
-                return icon;
+                return Icon.ExtractIcon(imageresPath, -1 * id, size).ToBitmap(); // Negative ID to extract from imageres.dll
             }
-            catch ( Exception ex )
+            catch (Exception ex)
             {
                 Console.WriteLine("Error loading icon: " + ex.Message);
                 return null;
             }
-        }
-
-        private static Bitmap? GetResizedIconFromImageRes(int id, int width, int height)
-        {
-            var icon = GetIconFromImageRes(id);
-            if ( icon == null )
-            {
-                return null;
-            }
-
-            Bitmap resizedBitmap = new Bitmap(width, height);
-            using ( Graphics g = Graphics.FromImage(resizedBitmap) )
-            {
-                g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
-                g.DrawImage(icon.ToBitmap(), new Rectangle(0, 0, width, height));
-            }
-
-            return resizedBitmap;
         }
 
         // Set the icons on the radio buttons to the actual icons
@@ -333,23 +314,23 @@ namespace Windows_Task_Dialog_Generator
 
 
             // Icon IDs aren't necessarily the same as the enum values, so we need to get the actual icon from the imageres.dll file
-            List<(RadioButton, int, int)> radioButtonsWithIcons =
+            List<(RadioButton, int)> radioButtonsWithIcons =
             [
-                (rbIconInformation,            81,  15), //Slightly smaller to not be cut off
-                (rbIconWarning,                84,  16),
-                (rbIconError,                  98,  15), //Slightly smaller to not be cut off
-                (rbIconShield,                 78,  16),
-                (rbIconShieldBlueBar,          78,  16),
-                (rbIconShieldGrayBar,          78,  16),
-                (rbIconShieldWarningYellowBar, 107, 16),
-                (rbIconShieldErrorRedBar,      105, 16),
-                (rbIconShieldSuccessGreenBar,  106, 16)
+                (rbIconInformation,            81),
+                (rbIconWarning,                84),
+                (rbIconError,                  98),
+                (rbIconShield,                 78),
+                (rbIconShieldBlueBar,          78),
+                (rbIconShieldGrayBar,          78),
+                (rbIconShieldWarningYellowBar, 107),
+                (rbIconShieldErrorRedBar,      105),
+                (rbIconShieldSuccessGreenBar,  106)
             ];
 
-            foreach ( (var radioButton, int iconID, int size) in radioButtonsWithIcons )
+            foreach ( (var radioButton, int iconID) in radioButtonsWithIcons )
             {
-                int ScaledSize = (int)(size * dpiScale);
-                radioButton.Image = GetResizedIconFromImageRes(iconID, ScaledSize, ScaledSize);
+                int ScaledSize = (int)((radioButton.Height - 8) * dpiScale);
+                radioButton.Image = GetIconImageFromImageRes(iconID, ScaledSize);
                 radioButton.ImageAlign = ContentAlignment.MiddleLeft;
                 radioButton.TextImageRelation = TextImageRelation.ImageBeforeText;
             }


### PR DESCRIPTION
Hey, it's me again. ☺️ Sorry for bugging you. I was looking for a solution and I genuinely started to think that the problem has something to do with the GDI+'s resizing algorithm. While doing some digging, I came across this: [.Net Core 8.0.0 - System.Drawing Diff](https://github.com/dotnet/core/blob/main/release-notes/8.0/8.0.0/api-diff/Microsoft.WindowsDesktop.App/8.0.0_System.Drawing.md?plain=1#L84). Well, basically `ExtractIcon` method has overload which you can specify the required size and it return a ready-to-use, resized icon. And it's introduced in .Net 8, fairly new. Using this method solved the #1's cropping problem on circle icons and also made all icons a bit less blurry and easy to see. I combined fetching and resizing function into single one. Tried testing this by setting my second monitor (which is also 1080p 100% scaling) to 125% and 150%. I can tell the difference but it would be great if you have a look with high DPI monitor.

Here are screenshots from my tests: (left: new, right: old)
![Screenshot 1](https://github.com/user-attachments/assets/74bb2663-e792-486d-a743-eb4df0dba204)
![Screenshot 2](https://github.com/user-attachments/assets/82b0892c-f481-4ce8-8f0c-e6447c1ded43)
(Second image captured with ZoomIt.)